### PR TITLE
Fixing Freezing

### DIFF
--- a/homepage
+++ b/homepage
@@ -182,6 +182,10 @@ class EloSorter {
         this.phase1InitialQueueSize = 0;
         this.lastPhase3OverlapSignature = null;
         this.polishStagnationDetected = false;
+        this.polishCycleCounter = 0;
+        // Set maxPolishCycles relative to item count; e.g., N*2 or N*3. For 14 items, N*2=28.
+        // This can be adjusted later if needed.
+        this.maxPolishCycles = this.items.length * 2; 
     }
     phase1() {
         for (let i = 0; i < this.items.length - 1; i++) {
@@ -191,10 +195,28 @@ class EloSorter {
         this.phase1Done = true;
     }
     phase2() {
-        this.lastPhase3OverlapSignature = null;
-        this.polishStagnationDetected = false;
-        // console.log("Reset polish stagnation fields due to new phase2 round."); // Optional debug log
-        this.round_start_step = this.stepCount;
+        // --- New code START ---
+        const recentDeltas = Object.values(this.data)
+            .filter(d => d.last_delta_update_step >= this.round_start_step) // Uses this.round_start_step from the *previous* round
+            .map(d => Math.abs(d.last_delta));
+        const maxDeltaValue = recentDeltas.length > 0 ? Math.max(...recentDeltas) : 0;
+
+        const isPolishingState = (this.bandRoundsDone >= this.cfg.minBandRounds) && 
+                                 (maxDeltaValue < this.cfg.stopDelta) && 
+                                 this.cfg.requireOverlap;
+
+        if (!isPolishingState) {
+            // Only reset if NOT primarily stuck on polishing overlaps
+            this.lastPhase3OverlapSignature = null;
+            this.polishStagnationDetected = false;
+            // console.log("Reset polish stagnation: Not in dedicated polish mode or overlap not required."); // Optional
+        } else {
+            // console.log("NOT resetting polish stagnation: In dedicated polish mode."); // Optional
+        }
+        // --- New code END ---
+
+        // Existing phase2 logic starts here, e.g.:
+        this.round_start_step = this.stepCount; 
         const sorted = [...this.items].sort((a,b) => this.data[b].rating - this.data[a].rating);
         const bands = [];
         for (let i = 0; i < sorted.length; i += this.cfg.bandSize) {
@@ -245,7 +267,7 @@ class EloSorter {
         }
 
         // If we reach here, no stagnation / different overlaps / first time / no overlaps
-        this.polishStagnationDetected = false; // Explicitly set to false if not stagnated
+        // REMOVED: this.polishStagnationDetected = false; 
         this.lastPhase3OverlapSignature = newOverlapSignature;
 
         if (pairsToQueue.length > 0) {
@@ -301,7 +323,39 @@ class EloSorter {
     next() {
         if (this.shouldStop()) return null;
         while (!this.queue.length) {
-            if (this.shouldStop()) return null;
+            // --- Polish Cycle Counter Logic START ---
+            // Calculate current maxDelta for this check
+            const currentMaxDeltaValueCheck = Object.values(this.data)
+                .filter(d => d.last_delta_update_step >= this.round_start_step)
+                .map(d => Math.abs(d.last_delta));
+            const currentMaxDelta = currentMaxDeltaValueCheck.length > 0 ? Math.max(...currentMaxDeltaValueCheck) : 0;
+        
+            // Define if we are in a state where only polishing should be happening
+            const isEffectivelyInPolishPhase = this.phase1Done &&
+                                             this.bandRoundsDone >= this.cfg.minBandRounds &&
+                                             currentMaxDelta < this.cfg.stopDelta &&
+                                             this.cfg.requireOverlap;
+                                             // AND shouldStop() would be false due to overlaps (implicitly, if queue needs filling)
+        
+            if (isEffectivelyInPolishPhase) {
+                // If we are in this state, it implies that if the queue is empty, 
+                // phase3 will be called to try and resolve overlaps.
+                // We increment the counter for each such "attempt cycle".
+                this.polishCycleCounter++;
+                // console.log("Polish cycle counter: ", this.polishCycleCounter, "Max:", this.maxPolishCycles); // Optional
+                if (this.polishCycleCounter > this.maxPolishCycles) {
+                    // console.log("Max polish cycles reached. Setting stagnation flag."); // Optional
+                    this.polishStagnationDetected = true; 
+                    // This flag will be checked by shouldStop() when it's next called.
+                }
+            } else {
+                // If not in this specific "stuck on polish" state, reset counter.
+                this.polishCycleCounter = 0;
+                // console.log("Polish cycle counter reset."); // Optional
+            }
+            // --- Polish Cycle Counter Logic END ---
+
+            if (this.shouldStop()) return null; // Re-check stop condition after counter logic
             if (!this.phase1Done) {
                 this.currentPhase = 'seed';
                 this.phase1();


### PR DESCRIPTION
I've made some improvements to prevent a freezing issue that could sometimes happen during the polishing phase of my work, especially when dealing with tricky overlapping code sections. The previous way I detected if I was stuck wasn't quite robust enough.

Here's how I've enhanced things:

1.  **More Consistent Stagnation Detection During Polishing:**
    *   I now have a better memory of the overlaps I've already seen during the polishing phase. This memory isn't reset prematurely if I need to briefly revisit an earlier stage while I'm in the middle of polishing.
    *   If I encounter the exact same set of overlaps I've just processed during the current polishing attempt, I'll recognize that I might be stuck.

2.  **A Safety Net for Polishing Cycles:**
    *   I've introduced a counter that keeps track of how many times I attempt to refine the code while I'm in the polishing state.
    *   If this counter gets too high, I'll flag that I might be stuck and stop, to avoid getting into an endless loop.
    *   This counter resets if I'm not actively in the polishing state (for example, if I'm still in the main learning rounds).

3.  **Stopping Condition:** I'll continue to check if I've detected stagnation to know when to halt the process.

These changes should make the polishing phase more resilient, ensuring I either complete the refinement or stop gracefully, preventing any freezes.